### PR TITLE
Rename variable 'message' to 'output' in RunAsync

### DIFF
--- a/Devantler.KustomizeCLI.Tests/KustomizeTests/RunAsyncTests.cs
+++ b/Devantler.KustomizeCLI.Tests/KustomizeTests/RunAsyncTests.cs
@@ -13,7 +13,7 @@ public class RunAsyncTests
   public async Task RunAsync_Version_ReturnsVersion()
   {
     // Act
-    var (exitCode, message) = await Kustomize.RunAsync(["version"]);
+    var (exitCode, output) = await Kustomize.RunAsync(["version"]);
 
     // Assert
     Assert.Equal(0, exitCode);

--- a/Devantler.KustomizeCLI.Tests/KustomizeTests/RunAsyncTests.cs
+++ b/Devantler.KustomizeCLI.Tests/KustomizeTests/RunAsyncTests.cs
@@ -17,6 +17,6 @@ public class RunAsyncTests
 
     // Assert
     Assert.Equal(0, exitCode);
-    Assert.Matches($"v\\d+\\.\\d+\\.\\d+", message);
+    Assert.Matches($"v\\d+\\.\\d+\\.\\d+", output);
   }
 }

--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ You can execute the Kustomize CLI commands using the `Kustomize` class.
 ```csharp
 using Devantler.KustomizeCLI;
 
-var (exitCode, message) = await Kustomize.RunAsync(["arg1", "arg2"]);
+var (exitCode, output) = await Kustomize.RunAsync(["arg1", "arg2"]);
 ```


### PR DESCRIPTION
Update the variable name in the RunAsync method to improve clarity and consistency.